### PR TITLE
Add an initial stab at PR support.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,3 +3,4 @@ source ENV['GEM_SOURCE'] || 'https://rubygems.org'
 gemspec
 
 gem 'cucumber', '< 3.0' if RUBY_VERSION < '2.1'
+gem 'octokit', '~> 4.0'

--- a/README.md
+++ b/README.md
@@ -176,6 +176,19 @@ touching the modules, you can deactivate the hook.
 msync hook deactivate
 ```
 
+#### Submitting PRs to GitHub
+
+You can have modulesync submit Pull Requests on GitHub automatically with the
+`--pr` CLI option.
+
+```
+msync update --pr
+```
+
+You must set `GITHUB_TOKEN` in your environment for this to work. You can set
+the PR title with `--pr-title` or in `modulesync.yml` with the `pr_title`
+attribute.
+
 ### Using Forks and Non-master branches
 
 The default functionality is to run ModuleSync on the puppetlabs modules, but

--- a/lib/modulesync.rb
+++ b/lib/modulesync.rb
@@ -1,4 +1,5 @@
 require 'fileutils'
+require 'octokit'
 require 'pathname'
 require 'modulesync/cli'
 require 'modulesync/constants'

--- a/lib/modulesync.rb
+++ b/lib/modulesync.rb
@@ -14,7 +14,7 @@ GITHUB_TOKEN = ENV.fetch('GITHUB_TOKEN', '')
 GITHUB_ORGANIZATION = ENV.fetch('GITHUB_ORGANIZATION', '')
 
 Octokit.configure do |c|
-  c.api_endpoint = ENV.fetch('GITHUB_BASE_URL', 'https://api.github.com/api/v3/')
+  c.api_endpoint = ENV.fetch('GITHUB_BASE_URL', 'https://api.github.com')
 end
 
 module ModuleSync

--- a/lib/modulesync.rb
+++ b/lib/modulesync.rb
@@ -121,13 +121,17 @@ module ModuleSync
     if options[:noop]
       Git.update_noop(module_name, options)
     elsif !options[:offline]
-      Git.update(module_name, files_to_manage, options)
-      if options[:pr] and GITHUB_TOKEN
-        repo_path = "#{namespace}/#{module_name}"
-        puts "Submitting PR on GitHub to #{repo_path}"
-        github = Octokit::Client.new(:access_token => GITHUB_TOKEN)
-        github.create_pull_request(repo_path, "master", options[:branch],
-          "Update to module template files", options[:message])
+      pushed = Git.update(module_name, files_to_manage, options)
+      if pushed and options[:pr]
+        if GITHUB_TOKEN
+          repo_path = "#{namespace}/#{module_name}"
+          puts "Submitting PR on GitHub to #{repo_path}"
+          github = Octokit::Client.new(:access_token => GITHUB_TOKEN)
+          github.create_pull_request(repo_path, "master", options[:branch],
+            "Update to module template files", options[:message])
+        else
+          puts "Environment variable GITHUB_TOKEN must be set to use --pr!"
+        end
       end
     end
   end

--- a/lib/modulesync.rb
+++ b/lib/modulesync.rb
@@ -125,10 +125,10 @@ module ModuleSync
       if pushed and options[:pr]
         if GITHUB_TOKEN
           repo_path = "#{namespace}/#{module_name}"
-          puts "Submitting PR on GitHub to #{repo_path}"
+          puts "Submitting PR '#{options[:pr_title]}' on GitHub to #{repo_path} - merges #{options[:branch]} into master"
           github = Octokit::Client.new(:access_token => GITHUB_TOKEN)
-          github.create_pull_request(repo_path, "master", options[:branch],
-            "Update to module template files", options[:message])
+          pr = github.create_pull_request(repo_path, "master", options[:branch], options[:pr_title], options[:message])
+          puts "PR created at #{pr["html_url"]}"
         else
           puts "Environment variable GITHUB_TOKEN must be set to use --pr!"
         end

--- a/lib/modulesync.rb
+++ b/lib/modulesync.rb
@@ -14,7 +14,7 @@ GITHUB_TOKEN = ENV.fetch('GITHUB_TOKEN', '')
 GITHUB_ORGANIZATION = ENV.fetch('GITHUB_ORGANIZATION', '')
 
 Octokit.configure do |c|
-  c.api_endpoint = ENV.fetch('GITHUB_BASE_URL', 'https://github.com/api/v3/')
+  c.api_endpoint = ENV.fetch('GITHUB_BASE_URL', 'https://api.github.com/api/v3/')
 end
 
 module ModuleSync

--- a/lib/modulesync.rb
+++ b/lib/modulesync.rb
@@ -9,6 +9,10 @@ require 'modulesync/settings'
 require 'modulesync/util'
 require 'monkey_patches'
 
+GITHUB_TOKEN = ENV.fetch('GITHUB_TOKEN', '')
+GITHUB_ORGANIZATION = ENV.fetch('GITHUB_ORGANIZATION', '')
+GITHUB_BASE_URL = ENV.fetch('GITHUB_BASE_URL', '')
+
 module ModuleSync
   include Constants
 
@@ -115,6 +119,13 @@ module ModuleSync
       Git.update_noop(module_name, options)
     elsif !options[:offline]
       Git.update(module_name, files_to_manage, options)
+      if options[:pr] and GITHUB_TOKEN
+        repo_path = "#{GITHUB_ORGANIZATION}/#{module_name}"
+        puts "Submitting PR to #{repo_path}"
+        github = Octokit::Client.new(:access_token => GITHUB_TOKEN)
+        github.create_pull_request(repo_path, "master", options[:branch],
+          "Update to module template files", options[:message])
+      end
     end
   end
 

--- a/lib/modulesync.rb
+++ b/lib/modulesync.rb
@@ -11,7 +11,6 @@ require 'modulesync/util'
 require 'monkey_patches'
 
 GITHUB_TOKEN = ENV.fetch('GITHUB_TOKEN', '')
-GITHUB_ORGANIZATION = ENV.fetch('GITHUB_ORGANIZATION', '')
 
 Octokit.configure do |c|
   c.api_endpoint = ENV.fetch('GITHUB_BASE_URL', 'https://api.github.com')
@@ -124,8 +123,8 @@ module ModuleSync
     elsif !options[:offline]
       Git.update(module_name, files_to_manage, options)
       if options[:pr] and GITHUB_TOKEN
-        repo_path = "#{GITHUB_ORGANIZATION}/#{module_name}"
-        puts "Submitting PR to #{repo_path}"
+        repo_path = "#{namespace}/#{module_name}"
+        puts "Submitting PR on GitHub to #{repo_path}"
         github = Octokit::Client.new(:access_token => GITHUB_TOKEN)
         github.create_pull_request(repo_path, "master", options[:branch],
           "Update to module template files", options[:message])

--- a/lib/modulesync.rb
+++ b/lib/modulesync.rb
@@ -11,7 +11,10 @@ require 'monkey_patches'
 
 GITHUB_TOKEN = ENV.fetch('GITHUB_TOKEN', '')
 GITHUB_ORGANIZATION = ENV.fetch('GITHUB_ORGANIZATION', '')
-GITHUB_BASE_URL = ENV.fetch('GITHUB_BASE_URL', '')
+
+Octokit.configure do |c|
+  c.api_endpoint = ENV.fetch('GITHUB_BASE_URL', 'https://github.com/api/v3/')
+end
 
 module ModuleSync
   include Constants

--- a/lib/modulesync/cli.rb
+++ b/lib/modulesync/cli.rb
@@ -85,6 +85,10 @@ module ModuleSync
              :type => :boolean,
              :desc => 'No-op mode',
              :default => false
+      option :pr,
+             :type => :boolean,
+             :desc => 'Submit GitHub PR',
+             :default => false
       option :offline,
              :type => :boolean,
              :desc => 'Do not run any Git commands. Allows the user to manage Git outside of ModuleSync.',

--- a/lib/modulesync/cli.rb
+++ b/lib/modulesync/cli.rb
@@ -89,6 +89,10 @@ module ModuleSync
              :type => :boolean,
              :desc => 'Submit GitHub PR',
              :default => false
+      option :pr_title,
+             :type => :boolean,
+             :desc => 'Title of GitHub PR',
+             :default => CLI.defaults[:pr_title] || 'Update to module template files'
       option :offline,
              :type => :boolean,
              :desc => 'Do not run any Git commands. Allows the user to manage Git outside of ModuleSync.',

--- a/lib/modulesync/git.rb
+++ b/lib/modulesync/git.rb
@@ -151,11 +151,14 @@ module ModuleSync
       rescue ::Git::GitExecuteError => git_error
         if git_error.message =~ /working (directory|tree) clean/
           puts "There were no files to update in #{name}. Not committing."
+          return false
         else
           puts git_error
           raise
         end
       end
+
+      return true
     end
 
     # Needed because of a bug in the git gem that lists ignored files as

--- a/modulesync.gemspec
+++ b/modulesync.gemspec
@@ -24,6 +24,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rubocop', '~> 0.50.0'
 
   spec.add_runtime_dependency 'git', '~>1.3'
+  spec.add_runtime_dependency 'octokit', '~>4.0'
   spec.add_runtime_dependency 'puppet-blacksmith', '~>3.0'
   spec.add_runtime_dependency 'thor'
 end


### PR DESCRIPTION
Adds a `--pr` flag that will trigger submitted a GitHub pull request using https://github.com/octokit/octokit.rb

Example output:

```
joestump-ltm3:dmp-modulesync-terraform joe.stump$ bundle exec msync update -b pr-test-2 --pr
Syncing dmp-iac-main-network
Overriding any local changes to repositories in modules
Creating new branch pr-test-2
No config file under modules/dmp-iac-main-network/.sync.yml found, using default values
Submitting PR 'Modulesync changes to base template files' on GitHub to krux/dmp-iac-main-network - merges pr-test-2 into master
PR created at https://github.com/krux/dmp-iac-main-network/pull/28
```

You can specify `--pr-title` on the CLI or you can add `pr_title` to `modulesync.yml`.